### PR TITLE
replace "active" account references for "acting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,27 +52,27 @@ Sets the authenticated user details
 
       ALSession.setUserAuthentication(proposal);
 
-Takes a proposal parameter in the format of an authentication response object defintion from AIMS - [response format](https://console.account.alertlogic.com/users/api/aims/#api-AIMS_Authentication_and_Authorization_Resources-Authenticate)
+Takes a proposal parameter in the format of an [AIMS authentication resource](https://console.account.alertlogic.com/users/api/aims/#api-AIMS_Authentication_and_Authorization_Resources-Authenticate)
 
 **getUserAuthentication**
 
-Returns currently logged in user's AIMS authentication object.
+Returns the currently logged in user's AIMS authentication resource.
   
       ALSession.getUserAuthentication();
 
-**setActive**
+**setActingAccount**
 
-Sets the active account for the current authenticated user
+Sets the acting account for the current authenticated user
 
-      ALSession.setActive(proposal)
+      ALSession.setActingAccount(account)
 
-Takes a proposal parameter in the format of an authentication account object defintion from AIMS - [response format](https://console.account.alertlogic.com/users/api/aims/#api-AIMS_Authentication_and_Authorization_Resources-Authenticate)
+Takes an account parameter in the format of an [AIMS account resource](https://console.account.alertlogic.com/users/api/aims/#api-AIMS_Authentication_and_Authorization_Resources-Authenticate)
 
-**getActive**
+**getActingAccount**
 
-Returns an AIMS authentication account details object for the current active account.
+Returns an the current acting account (modelled on an AIMS account).
 
-      ALSession.getActive();
+      ALSession.getActingAccount();
 
 **getToken**
 
@@ -96,17 +96,17 @@ Returns the current AIMS authentication token expiry.
 
 **getUserAccountID**
 
-**getCurrentAccessibleLocations**
+**getUserAccessibleLocations**
 
-## Convenience methods for active account
+## Convenience methods for acting account
 
-**getActiveAccountID**
+**getActingAccountID**
 
-**getActiveAccountName**
+**getActingAccountName**
 
-**getDefaultLocation**
+**getActingAccountDefaultLocation**
 
-**getAccessibleLocations**
+**getActingAccountAccessibleLocations**
 
 ## Interactive
 

--- a/src/al-session.ts
+++ b/src/al-session.ts
@@ -41,7 +41,7 @@ export interface AIMSAccount {
 
 interface AIMSSession {
   authentication: AIMSAuthentication;
-  active: AIMSAccount;
+  acting: AIMSAccount;
 }
 
 class ALSession {
@@ -53,8 +53,8 @@ class ALSession {
     if (this.validateProperty(persistedSession, 'authentication')) {
       this.setAuthentication(persistedSession.authentication);
     }
-    if (this.validateProperty(persistedSession, 'active')) {
-      this.setActive(persistedSession.active);
+    if (this.validateProperty(persistedSession, 'acting')) {
+      this.setActingAccount(persistedSession.acting);
     }
     this.activateSession();
   }
@@ -103,7 +103,7 @@ class ALSession {
       token: '',
       token_expiration: 0,
     },
-    active: {
+    acting: {
       id: '0',
       name: 'Unknown Company',
       active: false,
@@ -135,7 +135,7 @@ class ALSession {
   private setStorage() {
     if (this.sessionIsActive) {
       if (this.validateProperty(this.cacheSession, 'authentication')) {
-        if (this.validateProperty(this.cacheSession, 'active')) {
+        if (this.validateProperty(this.cacheSession, 'acting')) {
           localStorageFallback.setItem('al_session', JSON.stringify(this.cacheSession));
         }
       }
@@ -250,43 +250,43 @@ class ALSession {
   }
 
   /**
-   * Update 'active'
+   * Set the acting account for the current user
    * Modelled on /aims/v1/:account_id/account
    * To be called by AIMS Service
    */
-  setActive(proposal: AIMSAccount) {
-    if (this.validateProperty(proposal, 'id')) {
-      this.cacheSession.active.id = proposal.id;
+  setActingAccount(account: AIMSAccount) {
+    if (this.validateProperty(account, 'id')) {
+      this.cacheSession.acting.id = account.id;
     }
-    if (this.validateProperty(proposal, 'name')) {
-      this.cacheSession.active.name = proposal.name;
+    if (this.validateProperty(account, 'name')) {
+      this.cacheSession.acting.name = account.name;
     }
-    if (this.validateProperty(proposal, 'active')) {
-      this.cacheSession.active.active = proposal.active;
+    if (this.validateProperty(account, 'active')) {
+      this.cacheSession.acting.active = account.active;
     }
-    if (this.validateProperty(proposal, 'version')) {
-      this.cacheSession.active.version = proposal.version;
+    if (this.validateProperty(account, 'version')) {
+      this.cacheSession.acting.version = account.version;
     }
-    if (this.validateProperty(proposal, 'accessible_locations')) {
-      this.cacheSession.active.accessible_locations = proposal.accessible_locations;
+    if (this.validateProperty(account, 'accessible_locations')) {
+      this.cacheSession.acting.accessible_locations = account.accessible_locations;
     }
-    if (this.validateProperty(proposal, 'default_location')) {
-      this.cacheSession.active.default_location = proposal.default_location;
+    if (this.validateProperty(account, 'default_location')) {
+      this.cacheSession.acting.default_location = account.default_location;
     }
-    if (this.validateProperty(proposal, 'created')) {
-      if (this.validateProperty(proposal.created, 'at')) {
-        this.cacheSession.active.created.at = proposal.created.at;
+    if (this.validateProperty(account, 'created')) {
+      if (this.validateProperty(account.created, 'at')) {
+        this.cacheSession.acting.created.at = account.created.at;
       }
-      if (this.validateProperty(proposal.created, 'by')) {
-        this.cacheSession.active.created.by = proposal.created.by;
+      if (this.validateProperty(account.created, 'by')) {
+        this.cacheSession.acting.created.by = account.created.by;
       }
     }
-    if (this.validateProperty(proposal, 'modified')) {
-      if (this.validateProperty(proposal.modified, 'at')) {
-        this.cacheSession.active.modified.at = proposal.modified.at;
+    if (this.validateProperty(account, 'modified')) {
+      if (this.validateProperty(account.modified, 'at')) {
+        this.cacheSession.acting.modified.at = account.modified.at;
       }
-      if (this.validateProperty(proposal.modified, 'by')) {
-        this.cacheSession.active.modified.by = proposal.modified.by;
+      if (this.validateProperty(account.modified, 'by')) {
+        this.cacheSession.acting.modified.by = account.modified.by;
       }
     }
     this.setStorage();
@@ -344,10 +344,10 @@ class ALSession {
   }
 
   /**
-   * Get Active Account
+   * Get the acting account
    */
-  getActive(): AIMSAccount {
-    return this.cacheSession.active;
+  getActingAccount(): AIMSAccount {
+    return this.cacheSession.acting;
   }
 
   /**
@@ -395,35 +395,35 @@ class ALSession {
   /**
    * Get acting Account ID - (account the user is currently working in)
    */
-  getActiveAccountID(): string {
-    return this.cacheSession.active.id;
+  getActingAccountID(): string {
+    return this.cacheSession.acting.id;
   }
 
   /**
    * Get acting Account Name - (account the user is currently working in)
    */
-  getActiveAccountName(): string {
-    return this.cacheSession.active.name;
+  getActingAccountName(): string {
+    return this.cacheSession.acting.name;
   }
 
   /**
-   * Get Default Location for the active account
+   * Get Default Location for the acting account
    */
-  getDefaultLocation() {
-    return this.cacheSession.active.default_location;
+  getActingAccountDefaultLocation() {
+    return this.cacheSession.acting.default_location;
   }
 
   /**
-   * Get Accessible Locations for the active account
+   * Get Accessible Locations for the acting account
    */
-  getAccessibleLocations(): string[] {
-    return this.cacheSession.active.accessible_locations;
+  getActingAccountAccessibleLocations(): string[] {
+    return this.cacheSession.acting.accessible_locations;
   }
 
   /**
    * Get Accessible Locations for the users account
    */
-  getCurrentAccessibleLocations(): string[] {
+  getUserAccessibleLocations(): string[] {
     return this.cacheSession.authentication.account.accessible_locations;
   }
 }

--- a/test/al-session.spec.ts
+++ b/test/al-session.spec.ts
@@ -1,7 +1,7 @@
 
 import { ALSession, AIMSAuthentication, AIMSAccount } from '../src/index';
 import localStorageFallback from 'local-storage-fallback';
-import { defaultSession, defaultActive } from './mocks/default-session.mock';
+import { defaultSession, defaultActing } from './mocks/default-session.mock';
 import { expect } from 'chai';
 import { describe, before } from 'mocha';
 
@@ -88,7 +88,7 @@ describe('ALSession - AIMSAuthentication value persistance Test Suite:', () => {
   });
   describe('On retrieving the session user accessible locations', () => {
     it('should retrieve the persisted value', () => {
-      expect(ALSession.getCurrentAccessibleLocations()).to.deep.equal(authentication.account.accessible_locations);
+      expect(ALSession.getUserAccessibleLocations()).to.deep.equal(authentication.account.accessible_locations);
     });
   });
   describe('On setting the session token details', () => {
@@ -102,10 +102,10 @@ describe('ALSession - AIMSAuthentication value persistance Test Suite:', () => {
   });
 });
 
-describe('ALSession - Active AIMSAccount value persistance Test Suite:', () => {
-  let activeAccount: AIMSAccount;
+describe('ALSession - Acting AIMSAccount value persistance Test Suite:', () => {
+  let actingAccount: AIMSAccount;
   beforeEach(() => {
-    activeAccount = {
+    actingAccount = {
       id: '5',
       name: 'ACME Corp',
       active: false,
@@ -121,36 +121,36 @@ describe('ALSession - Active AIMSAccount value persistance Test Suite:', () => {
         by: 'al-ui-team',
       },
     };
-    ALSession.setActive(activeAccount);
+    ALSession.setActingAccount(actingAccount);
   });
-  describe('After setting the active account value of the session object', () => {
+  describe('After setting the acting account value of the session object', () => {
     it('should persist this to local storage"', () => {
-      expect(JSON.parse(localStorageFallback.getItem('al_session')).active).to.deep.equal(activeAccount);
+      expect(JSON.parse(localStorageFallback.getItem('al_session')).acting).to.deep.equal(actingAccount);
     });
   });
-  describe('On retrieving the session active account ID value', () => {
+  describe('On retrieving the session acting account ID value', () => {
     it('should retrieve the persisted value', () => {
-      expect(ALSession.getActiveAccountID()).to.equal(activeAccount.id);
+      expect(ALSession.getActingAccountID()).to.equal(actingAccount.id);
     });
   });
-  describe('On retrieving the session active account name value', () => {
+  describe('On retrieving the session acting account name value', () => {
     it('should retrieve the persisted value', () => {
-      expect(ALSession.getActiveAccountName()).to.equal(activeAccount.name);
+      expect(ALSession.getActingAccountName()).to.equal(actingAccount.name);
     });
   });
-  describe('On retrieving the session session active account value', () => {
+  describe('On retrieving the session session acting account value', () => {
     it('should retrieve the persisted value', () => {
-      expect(ALSession.getActive()).to.deep.equal(activeAccount);
+      expect(ALSession.getActingAccount()).to.deep.equal(actingAccount);
     });
   });
-  describe('On retrieving the session accessible locations', () => {
+  describe('On retrieving the acting account accessible locations', () => {
     it('should retrieve the persisted value', () => {
-      expect(ALSession.getAccessibleLocations()).to.equal(activeAccount.accessible_locations);
+      expect(ALSession.getActingAccountAccessibleLocations()).to.equal(actingAccount.accessible_locations);
     });
   });
-  describe('On retrieving the session default location', () => {
+  describe('On retrieving the acting account default location', () => {
     it('should retrieve the persisted value', () => {
-      expect(ALSession.getDefaultLocation()).to.equal(activeAccount.default_location);
+      expect(ALSession.getActingAccountDefaultLocation()).to.equal(actingAccount.default_location);
     });
   });
 });
@@ -190,15 +190,15 @@ describe('When attempting to setAuthentication with', () => {
 
 describe('When attempting to set with', () => {
   describe('no account property provided', () => {
-    it('should fallback to setting default active account values', () => {
-      ALSession.setActive({});
-      expect(ALSession.getActive()).to.deep.equal(defaultActive);
+    it('should fallback to setting default acting account values', () => {
+      ALSession.setActingAccount({});
+      expect(ALSession.getActingAccount()).to.deep.equal(defaultActing);
     });
   });
   describe('an account property provided that has empty created and modified properties', () => {
-    it('should fallback to setting default active account values', () => {
-      ALSession.setActive({ created: {}, modified: {} });
-      expect(ALSession.getActive()).to.deep.equal(defaultActive);
+    it('should fallback to setting default acting account values', () => {
+      ALSession.setActingAccount({ created: {}, modified: {} });
+      expect(ALSession.getActingAccount()).to.deep.equal(defaultActing);
     });
   });
 });

--- a/test/mocks/default-session.mock.ts
+++ b/test/mocks/default-session.mock.ts
@@ -34,7 +34,7 @@ export const defaultSession = {
     token: '',
     token_expiration: 0,
   },
-  active: {
+  acting: {
     id: '0',
     name: 'Unknown Company',
     active: false,
@@ -52,7 +52,7 @@ export const defaultSession = {
   },
 };
 
-export const defaultActive = {
+export const defaultActing = {
   id: '0',
   name: 'Unknown Company',
   active: false,


### PR DESCRIPTION
Keeping our terminology in line with rest of O3 framework to keep us sane!