### PR TITLE
Auth0 Detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/auth0-js": "^8.10.1",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.5",
+    "@types/sinon": "^7.0.13",
     "chai": "^4.2.0",
     "karma": "^4.0.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -52,6 +53,7 @@
     "karma-typescript": "^3.0.13",
     "mocha": "^5.2.0",
     "peer-deps-externals-webpack-plugin": "^1.0.4",
+    "sinon": "^7.3.2",
     "tslint": "^5.12.1",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^3.2.4",
@@ -60,7 +62,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
-    "@al/aims": "^1.0.0-rc.3",
+    "@al/aims": "^1.0.0-rc.4",
     "@al/client": "^1.0.0-rc.8",
     "@al/haversack": "^1.0.0-rc.3",
     "@al/subscriptions": "^1.0.0-rc.4",

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -32,7 +32,8 @@ export class AlSessionEndedEvent extends AlTriggeredEvent
  */
 export class AlActingAccountChangedEvent extends AlTriggeredEvent
 {
-    constructor( public actingAccount:AIMSAccount,
+    constructor( public previousAccount:AIMSAccount,
+                 public actingAccount:AIMSAccount,
                  public session:AlSessionInstance ) {
         super( "AlActingAccountChanged" );
     }

--- a/src/utilities/al-conduit-client.ts
+++ b/src/utilities/al-conduit-client.ts
@@ -16,7 +16,7 @@ export class AlConduitClient
     constructor() {
     }
 
-    public start() {
+    public start( targetDocument:Document = document ) {
         this.conduitUri = ALClient.resolveLocation( AlLocation.AccountsUI, '/conduit.html' );
         document.body.append( this.render() );
         AlStopwatch.once(this.validateReadiness, 5000);

--- a/test/al-conduit-client.spec.ts
+++ b/test/al-conduit-client.spec.ts
@@ -1,0 +1,14 @@
+import { AlConduitClient } from '../src/utilities';
+import { expect } from 'chai';
+import { describe, before } from 'mocha';
+
+describe('AlConduitClient', () => {
+    let conduitClient = new AlConduitClient();
+
+    describe("after initialization", () => {
+        expect( conduitClient['conduitUri'] ).to.equal( undefined );
+        expect( conduitClient['conduitWindow'] ).to.equal( undefined );
+        expect( conduitClient['conduitOrigin'] ).to.equal( undefined );
+        expect( conduitClient['requestIndex'] ).to.equal( 0 );
+    } );
+} );

--- a/test/al-conduit-client.spec.ts
+++ b/test/al-conduit-client.spec.ts
@@ -6,9 +6,20 @@ describe('AlConduitClient', () => {
     let conduitClient = new AlConduitClient();
 
     describe("after initialization", () => {
-        expect( conduitClient['conduitUri'] ).to.equal( undefined );
-        expect( conduitClient['conduitWindow'] ).to.equal( undefined );
-        expect( conduitClient['conduitOrigin'] ).to.equal( undefined );
-        expect( conduitClient['requestIndex'] ).to.equal( 0 );
+
+        it( "should have expected initial state", () => {
+            expect( conduitClient['conduitUri'] ).to.equal( undefined );
+            expect( conduitClient['conduitWindow'] ).to.equal( undefined );
+            expect( conduitClient['conduitOrigin'] ).to.equal( undefined );
+            expect( conduitClient['requestIndex'] ).to.equal( 0 );
+        } );
+    } );
+
+    describe(".render()", () => {
+        it( "should generate a valid document fragment", () => {
+            let fragment = conduitClient.render();
+
+            expect( true ).to.equal( true );        //  I have no fucking idea how to evaluate this object
+        } );
     } );
 } );

--- a/test/al-session-detector.spec.ts
+++ b/test/al-session-detector.spec.ts
@@ -2,9 +2,21 @@ import { AlSessionDetector, AlConduitClient } from '../src/utilities';
 import { AIMSAuthentication } from '@al/aims';
 import { expect } from 'chai';
 import { describe, before } from 'mocha';
+import * as sinon from 'sinon';
+
+class AlMockConduitClient extends AlConduitClient
+{
+    constructor() {
+        super();
+    }
+}
+
+class MockWebAuth
+{
+}
 
 describe('AlSessionDetector', () => {
-    let conduit = new AlConduitClient();
+    let conduit = new AlMockConduitClient();
     let sessionDetector = new AlSessionDetector( conduit );
 
     describe("after initialization", () => {
@@ -51,24 +63,6 @@ describe('AlSessionDetector', () => {
         } );
     } );
 
-    describe(".normalizeAIMSSessionData", () => {
-        it( "should calculate token expiration if it is not already included in the session data object", async () => {
-            let authenticationData = {
-                user: {
-                    id: 1,
-                    name: "Some User"
-                },
-                account: {
-                    id: 1,
-                    name: "Some Account"
-                },
-                token: "blahblahblah.eyJleHAiOjEwMDAwMDAwLCJzb21ldGhpbmcgZWxzZSI6ImhhaGEifQ==.blahblahblah"
-            };
-            let data = await sessionDetector['normalizeAIMSSessionData']( <any>authenticationData );
-            expect( data.token_expiration ).to.equal( 10000000 );
-        } );
-    } );
-
     describe(".extractUserInfo", () => {
         it( "should get an accountId/userId pair from validly formatted auth0 identity data", () => {
             let identityData = {
@@ -91,5 +85,4 @@ describe('AlSessionDetector', () => {
             expect( () => { sessionDetector['extractUserInfo']( identityData ); } ).to.throw();
         } );
     } );
-
 } );

--- a/test/al-session-detector.spec.ts
+++ b/test/al-session-detector.spec.ts
@@ -1,4 +1,5 @@
 import { AlSessionDetector, AlConduitClient } from '../src/utilities';
+import { AIMSAuthentication } from '@al/aims';
 import { expect } from 'chai';
 import { describe, before } from 'mocha';
 
@@ -12,7 +13,7 @@ describe('AlSessionDetector', () => {
         } );
     } );
 
-    describe("getAuth0Config", () => {
+    describe(".getAuth0Config", () => {
         it( "should produce configuration values in an expected way", () => {
             let config = sessionDetector.getAuth0Config();
             expect( config.domain ).to.equal("alertlogic.auth0.com");
@@ -25,6 +26,69 @@ describe('AlSessionDetector', () => {
             config = sessionDetector.getAuth0Config( { scope: "openid", prompt: "none" } );
             expect( config.scope ).to.equal( "openid" );
             expect( config.prompt ).to.equal( "none" );
+        } );
+    } );
+
+    describe(".getTokenExpiration", () => {
+        it( "should extract a timestamp from a properly formatted JWT", () => {
+            let timestamp = sessionDetector['getTokenExpiration']("blahblahblah.eyJleHAiOjEwMDAwMDAwLCJzb21ldGhpbmcgZWxzZSI6ImhhaGEifQ==.blahblahblah" );
+            expect( timestamp ).to.equal( 10000000 );
+        } );
+        it( "should return 0 for invalid JWTs", () => {
+            let timestamp;
+
+            //  Wrong wrapper format
+            timestamp = sessionDetector['getTokenExpiration']("totally wrong");
+            expect( timestamp ).to.equal( 0 );
+
+            //  Token information segment is not base64 encoded
+            timestamp = sessionDetector['getTokenExpiration']("blahblahblah.blahblahblah.blahblahblah" );
+            expect( timestamp ).to.equal( 0 );
+
+            //  Token information segment doesn't have an `exp` property
+            timestamp = sessionDetector['getTokenExpiration']("blahblahblah.eyJleHBpcmF0aW9uIjoxMDAwMDAwMCwia2V2aW4iOiJ3YXMgaGVyZSJ9.blahblahblah" );
+            expect( timestamp ).to.equal( 0 );
+        } );
+    } );
+
+    describe(".normalizeAIMSSessionData", () => {
+        it( "should calculate token expiration if it is not already included in the session data object", async () => {
+            let authenticationData = {
+                user: {
+                    id: 1,
+                    name: "Some User"
+                },
+                account: {
+                    id: 1,
+                    name: "Some Account"
+                },
+                token: "blahblahblah.eyJleHAiOjEwMDAwMDAwLCJzb21ldGhpbmcgZWxzZSI6ImhhaGEifQ==.blahblahblah"
+            };
+            let data = await sessionDetector['normalizeAIMSSessionData']( <any>authenticationData );
+            expect( data.token_expiration ).to.equal( 10000000 );
+        } );
+    } );
+
+    describe(".extractUserInfo", () => {
+        it( "should get an accountId/userId pair from validly formatted auth0 identity data", () => {
+            let identityData = {
+                "https://alertlogic.com/": {
+                    sub: "2:10001000-1000"
+                }
+            };
+            let identityInfo = sessionDetector['extractUserInfo']( identityData );
+            expect( identityInfo ).to.be.an( 'object' );
+            expect( identityInfo.accountId ).to.equal( "2" );
+            expect( identityInfo.userId ).to.equal( "10001000-1000" );
+        } );
+
+        it( "should throw in the face of invalid input data", () => {
+            let identityData = {
+                "https://mcdonalds-restaurants.com/": {
+                    sub: "2:10001000-1000"
+                }
+            };
+            expect( () => { sessionDetector['extractUserInfo']( identityData ); } ).to.throw();
         } );
     } );
 

--- a/test/al-session-detector.spec.ts
+++ b/test/al-session-detector.spec.ts
@@ -1,0 +1,31 @@
+import { AlSessionDetector, AlConduitClient } from '../src/utilities';
+import { expect } from 'chai';
+import { describe, before } from 'mocha';
+
+describe('AlSessionDetector', () => {
+    let conduit = new AlConduitClient();
+    let sessionDetector = new AlSessionDetector( conduit );
+
+    describe("after initialization", () => {
+        it( "should have known properties", () => {
+            expect( sessionDetector.authenticated ).to.equal( false );
+        } );
+    } );
+
+    describe("getAuth0Config", () => {
+        it( "should produce configuration values in an expected way", () => {
+            let config = sessionDetector.getAuth0Config();
+            expect( config.domain ).to.equal("alertlogic.auth0.com");
+            expect( config.responseType ).to.equal( "token id_token" );
+            expect( config.audience ).to.equal( "https://alertlogic.com/" );
+            expect( config.scope ).to.equal( "openid user_metadata" );
+            expect( config.prompt ).to.equal( true );
+            expect( config.redirectUri ).to.equal( window.location.origin );
+
+            config = sessionDetector.getAuth0Config( { scope: "openid", prompt: "none" } );
+            expect( config.scope ).to.equal( "openid" );
+            expect( config.prompt ).to.equal( "none" );
+        } );
+    } );
+
+} );

--- a/test/al-session.spec.ts
+++ b/test/al-session.spec.ts
@@ -1,4 +1,3 @@
-
 import { ALSession, AlSessionInstance } from '../src/index';
 import { AIMSSessionDescriptor, AIMSAccount } from '@al/client';
 import localStorageFallback from 'local-storage-fallback';


### PR DESCRIPTION
- Extended AlSessionDetector to actually detect/ingest auth0 sessions
- Greatly restructured AlSessionDetector for readability and testability
- Better unit tests (slightly)
- Exposed global utilities to dump session state and set acting account
- Updated authentication methods to call through to @al/aims instead of
  invoking directly
- Some other nice things