### PR TITLE
Conduit iFrame insertion

### DIFF
--- a/src/utilities/al-conduit-client.ts
+++ b/src/utilities/al-conduit-client.ts
@@ -19,7 +19,9 @@ export class AlConduitClient
     public start( targetDocument:Document = document ) {
         if ( AlConduitClient.refCount < 1 ) {
             AlConduitClient.document = targetDocument;
-            AlConduitClient.document.body.append( this.render() );
+            if ( targetDocument && targetDocument.body && typeof( targetDocument.body.appendChild ) === 'function' ) {
+                AlConduitClient.document.body.appendChild( this.render() );
+            }
             AlStopwatch.once(this.validateReadiness, 5000);
         }
         AlConduitClient.refCount++;


### PR DESCRIPTION
Updated conduit client to use `appendChild` instead of `append` to insert conduit iframe into the DOM.  This is more backwards compatible and, better yet, it *works with PhantomJS* (also, IE7!)

Also added better safety checks before using the provided `Document`, since it is best to trust no one, and believe nothing anyone says.

