### PR TITLE
US106941 - TA93391 - defender session link support

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,8 @@ module.exports = function (config) {
       },
       compilerOptions: {
         lib: [
-          "es2015",
+          "es6",
+          "es2017",
           "dom"
         ],
         esModuleInterop: true

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -51,3 +51,16 @@ export class AlActingAccountResolvedEvent extends AlTriggeredEvent
         super( "AlActingAccountResolved" );
     }
 }
+
+/**
+ * AlActiveDatacenterChangedEvent is broadcast by an AlSessionInstance whenever the active datacenter has been changed.
+ */
+export class AlActiveDatacenterChangedEvent extends AlTriggeredEvent
+{
+    constructor( public insightLocationId:string,
+                 public residency:string,
+                 public metadata:unknown ) {
+        super("AlActiveDatacenterChanged" );
+        console.log(`Notice: active datacenter changed to ${insightLocationId}/${residency}` );
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node",
     "declarationDir": "./dist/typings/",
     "lib": [
-      "es2015",
+      "es6",
+      "es2017",
       "dom"
     ]
   },


### PR DESCRIPTION
- Updated tsconfig to include es2017 array support
- Added event for active datacenter change
- Updated ALSession to trigger active datacenter change events whenever a change is detected, or the session is restored.
- Updated conduit client to detect "session ready" messages from legacy UI locations
- Updated conduit client to provide an `awaitExternalSession` method
  that generates a promise for session readiness for a given defender node