### PR TITLE
US107407 - TA93656 - Conduit/Resources

### DIFF
--- a/src/utilities/al-conduit-client.ts
+++ b/src/utilities/al-conduit-client.ts
@@ -125,6 +125,19 @@ export class AlConduitClient
     }
 
     /**
+     * Retrieves a global resource.
+     */
+    public getGlobalResource( resourceName:string, ttl:number ): Promise<any> {
+        return this.request('conduit.getGlobalResource', { resourceName, ttl } )
+                            .then( response => {
+                                if ( ! response.resource ) {
+                                    return Promise.reject( response.error || `AlConduitClient failed to retrieve global resource '${resourceName}'` );
+                                }
+                                return response.resource;
+                            } );
+    }
+
+    /**
      * Receives a message from conduit, and dispatches it to the correct handler.
      */
     public onReceiveMessage = (event: any):void => {
@@ -153,6 +166,7 @@ export class AlConduitClient
             case 'conduit.getGlobalSetting':
             case 'conduit.setGlobalSetting':
             case 'conduit.deleteGlobalSetting':
+            case 'conduit.getGlobalResource':
                 return this.onDispatchReply(event);
             case "conduit.externalSessionReady":
                 return this.onExternalSessionEstablished(event);

--- a/test/al-conduit-client.spec.ts
+++ b/test/al-conduit-client.spec.ts
@@ -19,7 +19,7 @@ describe('AlConduitClient', () => {
                 type: requestType,
                 requestId: requestId || 'fakeId'
             },
-            origin: AlLocatorService.resolveNodeURI( AlLocatorService.getNode( AlLocation.AccountsUI ) ),
+            origin: AlLocatorService.resolveURL( AlLocation.AccountsUI ),
             source: {}
         };
         if ( data ) {
@@ -178,6 +178,30 @@ describe('AlConduitClient', () => {
 
             dispatchStub.restore();
         } );
+        it( "should handle conduit.getGlobalSetting, conduit.setGlobalSetting, and conduit.deleteGlobalSetting", () => {
+            let dispatchStub = sinon.stub( conduitClient, 'onDispatchReply' );
+
+            let event = generateMockRequest( 'conduit.getGlobalSetting', { setting_key: 'someSetting' } );
+            conduitClient.onReceiveMessage( event );
+
+            event = generateMockRequest( 'conduit.setGlobalSetting', { setting_key: 'someSetting', setting_data: { structured: true, deep: { reference: "maybe?" }, label: "Kevin wuz here" } } );
+            conduitClient.onReceiveMessage( event );
+
+            event = generateMockRequest( 'conduit.deleteGlobalSetting', { setting_key: 'someSetting' } );
+            conduitClient.onReceiveMessage( event );
+
+            expect( dispatchStub.callCount ).to.equal( 3 );
+
+            dispatchStub.restore();
+        } );
+        it( "should handle conduit.getGlobalResource", () => {
+            let dispatchStub = sinon.stub( conduitClient, 'onDispatchReply' );
+
+            let event = generateMockRequest( 'conduit.getGlobalResource', { resourceName: 'navigation/cie-plus2', ttl: 60 } );
+            conduitClient.onReceiveMessage( event );
+
+            dispatchStub.restore();
+        } );
         it( "should warn about invalid message types", () => {
 
             let event = {
@@ -185,7 +209,7 @@ describe('AlConduitClient', () => {
                     type: 'conduit.notARealMethod',
                     requestId: 'fakeId',
                 },
-                origin: AlLocatorService.resolveNodeURI( AlLocatorService.getNode( AlLocation.AccountsUI ) ),
+                origin: AlLocatorService.resolveURL( AlLocation.AccountsUI ),
                 source: {}
             };
             conduitClient.onReceiveMessage( event );
@@ -251,7 +275,7 @@ describe('AlConduitClient', () => {
                 source: {
                     postMessage: sinon.stub()
                 },
-                origin: ALClient.resolveLocation( AlLocation.AccountsUI ),
+                origin: AlLocatorService.resolveURL( AlLocation.AccountsUI ),
                 data: {
                     type: 'conduit.ready',
                     requestId: 'yohoho'


### PR DESCRIPTION
- Adds a method `getGlobalResource` to `AlConduitClient`.
- Adds support for replies using the key `conduit.getGlobalResource`.
- Replaces use of deprecated `resolveNodeURI` method with `resolveURL`
- Supporting tests.