### PR TITLE
AlConduitClient - Request Timeouts

### DIFF
--- a/test/al-conduit-client.spec.ts
+++ b/test/al-conduit-client.spec.ts
@@ -257,7 +257,7 @@ describe('AlConduitClient', () => {
         } );
 
         it( "should call through and clear existing request callbacks", () => {
-            AlConduitClient['requests']['fake-one'] = () => { calledThrough = true; };
+            AlConduitClient['requests']['fake-one'] = { resolve: () => { calledThrough = true; }, reject: () => {} };
             let event = generateMockRequest( 'conduit.getSession', null, 'fake-one' );
             conduitClient.onDispatchReply( event );
             expect( warnStub.callCount ).to.equal( 0 );
@@ -308,7 +308,7 @@ describe('AlConduitClient', () => {
                     requestId: requestId,
                     answer: "NO"
                 };
-                AlConduitClient['requests'][requestId]( responseData );
+                AlConduitClient['requests'][requestId].resolve( responseData );
             }, 100 );
         } );
     } );


### PR DESCRIPTION
- Updated AlConduitClient to capture both `resolve` and `reject` callbacks
  for request promises
- Added capability to pass a timeout to `request`
- Added logic to cancel outstanding requests and `reject` timed out
  requests