### PR TITLE
Lambda/Bundling Optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,7 @@
     "@al/client": "^1.1.0",
     "@al/common": "^1.1.0",
     "@al/subscriptions": "^1.1.0",
-    "auth0-js": "^9.11.1",
-    "local-storage-fallback": "^4.1.1",
-    "qs": "^6.7.0"
+    "auth0-js": "^9.11.1"
   },
   "peerDependencies": {},
   "files": [

--- a/src/utilities/al-conduit-client.ts
+++ b/src/utilities/al-conduit-client.ts
@@ -206,9 +206,11 @@ export class AlConduitClient
             return;
         }
         console.log(`Notice: received external session confirmation for location [${event.data.locationId}]` );
-        if ( AlConduitClient.externalSessions.hasOwnProperty( event.data.locationId ) ) {
-            AlConduitClient.externalSessions[event.data.locationId].resolver();
-        } else {
+        const session = AlConduitClient.externalSessions.hasOwnProperty( event.data.locationId ) ? AlConduitClient.externalSessions[event.data.locationId] : null;
+
+        if ( session && session.resolver ) {
+            session.resolver();
+        } else if ( ! session ) {
             AlConduitClient.externalSessions[event.data.locationId] = {
                 promise: Promise.resolve(),
                 resolver: null

--- a/src/utilities/al-session-detector.ts
+++ b/src/utilities/al-session-detector.ts
@@ -310,7 +310,7 @@ export class AlSessionDetector
     getTokenExpiration( token:string ) {
         const split = token.split('.');
         if (!split || split.length < 2 ) {
-            console.warn("Warning: unexpected JWT format causing existing session not to be recognized." );
+            console.warn("Warning: unexpected JWT format causing existing session not to be recognized.", token );
             return 0;
         }
         const base64Url = split[1];

--- a/test/al-session-detector.spec.ts
+++ b/test/al-session-detector.spec.ts
@@ -235,17 +235,26 @@ describe('AlSessionDetector', () => {
             } );
         } );
         describe("with an auth0 session", () => {
+            let getTokenInfoStub;
+            beforeEach( () => {
+                getTokenInfoStub = sinon.stub( AIMSClient, 'getTokenInfo' ).returns( Promise.resolve( exampleSession.authentication ) );
+            } );
+            afterEach( () => {
+                getTokenInfoStub.restore();
+            } );
             it( "should resolve true", ( done ) => {
                 ALSession.deactivateSession();
 
                 let auth0AuthStub = sinon.stub( sessionDetector, 'getAuth0Authenticator' ).returns( <WebAuth><unknown>{
                     checkSession: ( config, callback ) => {
+                        console.log("In checkSession mock!" );
                         callback( null, {
-                            accessToken: 'big-fake-access-token'
+                            accessToken: 'big-fake-access-token.' + window.btoa( JSON.stringify( { 'exp': Math.floor( ( Date.now() / 1000 ) + 86400 ) } ) )
                         } );
                     },
                     client: {
                         userInfo: ( accessToken, callback ) => {
+                            console.log("In UserInfo mock!" );
                             callback( null, {
                                 "https://alertlogic.com/": {
                                     sub: "2:10001000-1000"
@@ -261,9 +270,12 @@ describe('AlSessionDetector', () => {
                     getSessionStub.restore();
                     auth0AuthStub.restore();
                     expect( true ).to.equal( true );
+                    console.log("All done!" );
                     done();
                 }, error => {
                     expect( "Shouldn't get a promise rejection!").to.equal( false );
+                } ).catch( e => {
+                    expect("Shouldn't get an error" ).to.equal( false );
                 } );
             } );
         } );


### PR DESCRIPTION
- Removed unnecessary qs and local-storage-fallback packages
- Removed all references to AlSchemaValidator
- Replaced session validation with hardcoded validation routine
- Replaced localStorageFallback with AlCabinet
- Added logic to prevent conduit external session recognition from
  resolving a promise that doesn't have a resolver assigned yet (blah)
- Adjusted unit tests to take all these changes into account