### PR TITLE
v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/session",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "MIT",
   "description": "A client for maintaining Alert Logic session data",
   "author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './types';
 export * from './events';
 export * from './utilities';
 export {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,13 @@
+import { AlEndpointsServiceCollection } from '@al/client';
+import { AIMSAccount, AIMSUser } from '@al/aims';
+import { AlEntitlementRecord } from '@al/subscriptions';
+
+export interface AlConsolidatedAccountMetadata {
+    user:AIMSUser;
+    primaryAccount:AIMSAccount;
+    actingAccount:AIMSAccount;
+    managedAccounts:AIMSAccount[];
+    primaryEntitlements:AlEntitlementRecord[];
+    effectiveEntitlements:AlEntitlementRecord[];
+    endpointsData:AlEndpointsServiceCollection;
+}


### PR DESCRIPTION
- Added `reset` utility method to ALSession to reset session/locator
  (and optionally ALClient) state to factory defaults
- Added `setGlobalParameters` option to determine behavior patterns for session
- Added type and utility method to receive consolidated acting account
  resolution data from gestalt API; not yet activated.