### PR TITLE
Ingest existing session error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/session",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": "MIT",
   "description": "A client for maintaining Alert Logic session data",
   "author": {

--- a/src/utilities/al-session-detector.ts
+++ b/src/utilities/al-session-detector.ts
@@ -148,7 +148,7 @@ export class AlSessionDetector
     ingestExistingSession = async ( proposedSession: AIMSSessionDescriptor ):Promise<boolean> => {
         let session = await this.normalizeSessionDescriptor( proposedSession );
         try {
-            ALSession.setAuthentication( session );
+            await ALSession.setAuthentication( session );
             this.authenticated = ALSession.isActive();
             return true;
         } catch( e ) {

--- a/test/al-session-detector.spec.ts
+++ b/test/al-session-detector.spec.ts
@@ -1,5 +1,5 @@
 import { AlSessionDetector, AlConduitClient } from '../src/utilities';
-import { ALSession } from '../src';
+import { ALSession, AlActingAccountResolvedEvent } from '../src';
 import { AIMSClient, AIMSAuthentication, AIMSSessionDescriptor } from '@al/aims';
 import { exampleSession } from './mocks/session-data.mocks';
 import { expect } from 'chai';
@@ -220,11 +220,13 @@ describe('AlSessionDetector', () => {
             it( "should resolve true", ( done ) => {
                 ALSession.deactivateSession();
                 let getSessionStub = sinon.stub( conduit, 'getSession' ).returns( Promise.resolve( exampleSession ) );
+                let ingestSessionStub = sinon.stub( sessionDetector, 'ingestExistingSession' ).returns( Promise.resolve( true ) );
                 sessionDetector.detectSession().then( result => {
                     expect( result ).to.equal( true );
                     expect( sessionDetector.authenticated ).to.equal( true );
                     sessionDetector.onDetectionFail( () => {} );      //  kill the promise
                     getSessionStub.restore();
+                    ingestSessionStub.restore();
                     done();
                 }, error => {
                     expect( "Shouldn't get a promise rejection!").to.equal( false );
@@ -261,11 +263,12 @@ describe('AlSessionDetector', () => {
                     }
                 } );
                 let getSessionStub = sinon.stub( conduit, 'getSession' ).returns( Promise.resolve( null ) );
-
+                let ingestSessionStub = sinon.stub( sessionDetector, 'ingestExistingSession' ).returns( Promise.resolve( true ) );
                 sessionDetector.detectSession().then( result => {
                     sessionDetector.onDetectionFail( () => {} );      //  kill the promise
                     getSessionStub.restore();
                     auth0AuthStub.restore();
+                    ingestSessionStub.restore();
                     expect( true ).to.equal( true );
                     console.log("All done!" );
                     done();


### PR DESCRIPTION
- adds error handling when attempting to setAuthentication during existing session ingestion operation

Previously we have been encountering situations where the token expires, but is not being correctly handled:

![image](https://user-images.githubusercontent.com/10373419/69146005-ca2d7300-0ac6-11ea-805a-58362e4e1e51.png)

With these changes, this is now gracefully handled and consumers can now detect failures properly and do whatever - in our typical use case, redirect users to login
