### PR TITLE
Bug Fix - Disabled Account Resolution (1.1.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/session",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "license": "MIT",
   "description": "A client for maintaining Alert Logic session data",
   "author": {

--- a/src/al-session.ts
+++ b/src/al-session.ts
@@ -268,7 +268,7 @@ export class AlSessionInstance
 
       if ( ! this.options.resolveAccountMetadata ) {
         //  If metadata resolution is disabled, still trigger changed/resolved events with basic data
-        this.resolvedAccount = new AlActingAccountResolvedEvent( account, null, null );
+        this.resolvedAccount = new AlActingAccountResolvedEvent( account, [], new AlEntitlementCollection() );
         this.notifyStream.trigger( new AlActingAccountChangedEvent( previousAccount, account, this ) );
         this.resolutionGuard.resolve(true);
         this.notifyStream.trigger( this.resolvedAccount );


### PR DESCRIPTION
Update ALSession to trigger AlActingAccountResolvedEvents with empty managed accounts/entitlements, instead of null.  Fixes some errors in unit tests where account metadata resolution is explicitly disabled.