### PR TITLE
Acting Account/Location Binding Authentication Override

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/auth0-js": "^8.10.1",
-    "@types/chai": "^4.2.6",
+    "@types/chai": "^4.2.9",
     "@types/mocha": "^5.2.5",
     "@types/sinon": "^7.5.1",
     "chai": "^4.2.0",
@@ -52,17 +52,17 @@
     "sinon": "^7.3.2",
     "tslint": "^5.12.1",
     "tslint-config-airbnb": "^5.11.1",
-    "typescript": "^3.2.4",
-    "webpack": "^4.29.0",
-    "webpack-cli": "^3.2.1",
+    "typescript": "^3.7.5",
+    "webpack": "^4.41.6",
+    "webpack-cli": "^3.3.11",
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
     "@al/aims": "^1.1.3",
-    "@al/client": "^1.1.12",
-    "@al/common": "^1.1.12",
-    "@al/subscriptions": "^1.1.4",
-    "auth0-js": "^9.11.1"
+    "@al/client": "^1.1.13",
+    "@al/common": "^1.1.30",
+    "@al/subscriptions": "^1.1.6",
+    "auth0-js": "^9.12.2"
   },
   "peerDependencies": {},
   "files": [

--- a/test/al-session.spec.ts
+++ b/test/al-session.spec.ts
@@ -397,6 +397,25 @@ describe('AlSession', () => {
 
     } );
 
+    describe( 'with acting account/location override', () => {
+      it("should work", async () => {
+        let session = new AlSessionInstance();
+        let clientAuthStub = sinon.stub( ALClient, 'authenticate' ).returns( Promise.resolve( exampleSession ) );
+
+        let fakeAccount = {
+          id: '6710880',
+          name: 'Big Bird & Friends, Inc.'
+        } as AIMSAccount;
+
+        expect( session.isActive() ).to.equal( false );
+        let result = await session.authenticate( "mcnielsen@alertlogic.com", "b1gB1rdL!ves!", { actingAccount: fakeAccount, locationId: "defender-uk-newport" } );
+        expect( session.isActive() ).to.equal( true );
+        expect( session.getActingAccountId() ).to.equal( "6710880" );
+        expect( session.getActiveDatacenter() ).to.equal( "defender-uk-newport" );
+        clientAuthStub.restore();
+      } );
+    } );
+
   } );
 
   describe( 'helper methods', () => {


### PR DESCRIPTION
Allows calls to `authenticate()` and related methods to accept optional
overrides for the post-authentication acting account and bound location.