### PR TITLE
Navigation Extensions, Phase II

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/session",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "license": "MIT",
   "description": "A client for maintaining Alert Logic session data",
   "author": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@al/aims": "^1.1.3",
     "@al/client": "^1.1.13",
-    "@al/common": "^1.1.35",
+    "@al/common": "^1.2.0",
     "@al/subscriptions": "^1.1.7",
     "auth0-js": "^9.12.2"
   },

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -2,6 +2,7 @@ import { AlTrigger, AlTriggeredEvent } from '@al/common';
 import { AIMSUser, AIMSAccount } from '@al/client';
 import { AlEntitlementCollection } from '@al/subscriptions';
 import { AlSessionInstance } from '../al-session';
+import { AlExperienceTree } from '../types/al-experience.types';
 
 /**
  * AlSessionStartedEvent is broadcast by an AlSessionInstance whenever a new session is created by a successful authentication.
@@ -43,15 +44,16 @@ export class AlActingAccountChangedEvent extends AlTriggeredEvent<void>
 
 /**
  * AlActingAccountResolvedEvent is broadcast by an AlSessionInstance whenever the acting account has been changed
- * and its roles, entitlements, and managed children have been retrieved from their respective services.  This event is the second half of the process
- * whose beginning is indicated by AlActingAccountChangedEvent.
+ * and its roles, entitlements (acting and primary), and other state data have been retrieved from their respective services.
+ * This event is the second half of the process whose beginning is indicated by AlActingAccountChangedEvent.
  */
 @AlTrigger( 'AlActingAccountResolved' )
 export class AlActingAccountResolvedEvent extends AlTriggeredEvent<void>
 {
     constructor( public actingAccount:AIMSAccount,
-                 public managedAccounts:AIMSAccount[],
-                 public entitlements:AlEntitlementCollection ) {
+                 public entitlements:AlEntitlementCollection,
+                 public primaryEntitlements:AlEntitlementCollection,
+                 public experiences:AlExperienceTree ) {
         super();
     }
 }

--- a/src/types/al-experience.types.ts
+++ b/src/types/al-experience.types.ts
@@ -1,0 +1,25 @@
+import { getJsonPath } from '@al/common';
+
+export interface AlExperienceNode {
+    available?:string[];
+    selected?:string;
+    prompt?:string;
+    [child:string]:null|string|string[]|AlExperienceTree;
+}
+
+export class AlExperienceTree implements AlExperienceNode {
+    public available:string[] = [];
+    public selected:string = null;
+    public prompt:string = null;
+    [child:string]:any;
+
+    constructor( raw?:unknown ) {
+        if ( raw ) {
+            Object.assign( this, raw );
+        }
+    }
+
+    public query<Type=any>( path:string|string[], defaultValue?:Type ):Type {
+        return getJsonPath( this, path, defaultValue );
+    }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import { AlEndpointsServiceCollection } from '@al/client';
 import { AIMSAccount, AIMSUser } from '@al/aims';
 import { AlEntitlementRecord } from '@al/subscriptions';
+import { AlExperienceNode } from './al-experience.types';
 
 export interface AlConsolidatedAccountMetadata {
     user:AIMSUser;
@@ -9,5 +10,8 @@ export interface AlConsolidatedAccountMetadata {
     managedAccounts?:AIMSAccount[];
     primaryEntitlements:AlEntitlementRecord[];
     effectiveEntitlements:AlEntitlementRecord[];
+    experiences:AlExperienceNode;
     endpointsData:AlEndpointsServiceCollection;
 }
+
+export * from './al-experience.types';

--- a/test/al-conduit-client.spec.ts
+++ b/test/al-conduit-client.spec.ts
@@ -301,4 +301,42 @@ describe('AlConduitClient', () => {
             }, 100 );
         } );
     } );
+
+    describe( ".checkExternalSession()", () => {
+        it("should return a value immediately based on location", () => {
+            AlConduitClient['externalSessions']['fake-location-id'] = {
+                resolver: null,
+                resolved: true,
+                promise: null
+            };
+            expect( conduitClient.checkExternalSession("defender-uk-newport") ).to.equal( false );
+            expect( conduitClient.checkExternalSession("fake-location-id") ).to.equal( true );
+            expect( conduitClient.checkExternalSession() ).to.equal( false );
+        } );
+    } );
+
+    xdescribe( ".awaitExternalSession()", () => {
+        it("should wait until a established message is received", async () => {
+            AlLocatorService.setActingUri("https://console.clouddefender.alertlogic.com" );     //  implies defender-us-denver location
+            let promise = conduitClient.awaitExternalSession();                                 //  should check for default location for user denver
+            conduitClient.onReceiveMessage( {
+                origin: "https://console.account.alertlogic.com",
+                source: {},
+                data: {
+                    type: "conduit.externalSessionReady",
+                    requestId: "NA",
+                    locationId: "defender-us-denver"
+                }
+            } );
+            await promise;
+            expect( true ).to.equal( true );
+        } );
+    } );
+
+    xdescribe( ".getGlobalResource()", () => {
+        it("should resolve promise with reply's payload", async () => {
+            let promise = conduitClient.getGlobalResource( "fake/resource/id", 100 );
+            await promise;
+        } );
+    } );
 } );

--- a/test/al-session.spec.ts
+++ b/test/al-session.spec.ts
@@ -449,6 +449,17 @@ describe('AlSession', () => {
       } );
     } );
 
+    describe( ".getPrimaryEntitlementsSync()", () => {
+        it("should return null in an unauthenticated state", () => {
+            expect( session.getPrimaryEntitlementsSync() ).to.equal( null );
+        } );
+        it("should return viable entitlements if the session is authenticated", async () => {
+            session.setAuthentication( exampleSession );
+            await session.resolved();
+            expect( session.getPrimaryEntitlementsSync() ).to.equal( session['resolvedAccount']['primaryEntitlements'] );
+        } );
+    } );
+
     describe( ".getPrimaryEntitlements()", () => {
       it("should return the entitlements of the primary account after account resolution is finished", ( done ) => {
         session.getPrimaryEntitlements().then( primaryEntitlements => {
@@ -457,6 +468,17 @@ describe('AlSession', () => {
         } );
         session.setAuthentication( exampleSession );
       } );
+    } );
+
+    describe( ".getEffectiveEntitlementsSync()", () => {
+        it("should return null in an unauthenticated state", () => {
+            expect( session.getEffectiveEntitlementsSync() ).to.equal( null );
+        } );
+        it("should return viable entitlements if the session is authenticated", async () => {
+            session.setAuthentication( exampleSession );
+            await session.resolved();
+            expect( session.getEffectiveEntitlementsSync() ).to.equal( session['resolvedAccount'].entitlements );
+        } );
     } );
 
     describe( ".getEffectiveEntitlements()", () => {
@@ -473,7 +495,7 @@ describe('AlSession', () => {
       it("should return the list of accounts managed by the primary account after account resolution is finished", async () => {
         session.setAuthentication( exampleSession );
         let accountList = await session.getManagedAccounts();
-        expect( accountList ).to.equal( managedAccounts );
+        expect( accountList ).to.deep.equal( managedAccounts );
       } );
     } );
 


### PR DESCRIPTION
1.  Bumped version to 1.2.0
2.  Add `AlExperienceTree` stub type for managing experience options (experimental)
3.  Removed managed accounts from account resolved event
4.  Added primary entitlements and stub experience tree to account resolved event
5.  Added syncronous convenience methods to get primary and effective entitlements for the current session
6.  Removed console utility `modifyEntitlements`, since AlNavigationService now supports the same functionality